### PR TITLE
Set module as commonjs so the built package can be imported correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.3",
   "description": "A pure typescript BMP encoder and decoder",
   "main": "dist/index.js",
+  "exports": "./dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2017",
     "declaration": true,
     "lib": ["esnext"],
+    "module": "commonjs",
     "moduleResolution": "node",
     "downlevelIteration": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Currently the built `js` files cannot be imported from nodejs project as they are using `module import`
```js
// dist/index.js
import BmpDecoder from './decoder';
import BmpEncoder from './encoder';
```
But this package does not have 
```
 "type": "module",
``` 
in its `package.json`.

To make it more compatilble, this PR makes them to commonjs requires.