### PR TITLE
FIX decode error when image is bottom up

### DIFF
--- a/lib/decoder.ts
+++ b/lib/decoder.ts
@@ -84,6 +84,9 @@ export default class BmpDecoder implements IImage {
 
     this.width = this.readUInt32LE();
     this.height = this.readUInt32LE();
+    // negative value are possible here => implies bottom down
+    this.height =
+    this.height > 0x7fffffff ? this.height - 0x100000000 : this.height;
 
     this.planes = this.buffer.readUInt16LE(this.pos);
     this.pos += 2;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,3 +6,10 @@ export default {
     new BmpDecoder(bmpData, options),
   encode: (imgData: IImage) => new BmpEncoder(imgData)
 };
+
+export function decode(bmpData: Buffer, options?: IDecoderOptions) {
+  return new BmpDecoder(bmpData, options);
+}
+export function encode(imgData: IImage) {
+  return new BmpEncoder(imgData);
+}


### PR DESCRIPTION
small bugfix, when a BMP image is bottom out of jimp getBufferAsync, the height is a negative value. Also added function exports, and BTW the npm package for 1.0.4 is broken